### PR TITLE
Update org.json version to 20160810

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ## [Unreleased]
 
+### Changed
+- Update org.json version to 20160810
+
 ## [1.5.0] - 2016-12-01
 
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <mockito.version>1.10.19</mockito.version>
         <openejb.version>7.0.0-M3</openejb.version>
         <org.eclipse.sisu.plexus.version>0.3.2</org.eclipse.sisu.plexus.version>
-        <org.json.version>20160212</org.json.version>
+        <org.json.version>20160810</org.json.version>
         <persistence-api.version>1.0.2</persistence-api.version>
         <plexus-utils.version>3.0.22</plexus-utils.version>
         <raml-parser.version>0.8.12</raml-parser.version>


### PR DESCRIPTION
This is required as org.everit.json.schema depends on it and tests are failing with "NoClassDefFoundError: org/json/JSONPointerException". Sorry, as this should have been identified much earlier.