### PR TITLE
Update log4j2 to 2.15.0 to fix security vulnerability https://www.ran…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## [7.2.0] - 2021-12-13
+### Changed
+- Updated log4j2 to 2.15.0 to fix security vulnerability https://www.randori.com/blog/cve-2021-44228/ 
+
 ## [7.1.1] - 2020-10-14
 ### Changed
 - Updated various library dependencies to fix security vulnerabilities: 

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <jsonpath.version>2.2.0</jsonpath.version>
         <junit.version>4.13.1</junit.version>
         <log4j.version>1.2.17</log4j.version>
-        <log4j2.version>2.11.1</log4j2.version>
+        <log4j2.version>2.15.0</log4j2.version>
         <maven-aether-provider.version>3.3.9</maven-aether-provider.version>
         <maven-compat.version>3.3.9</maven-compat.version>
         <maven-core.version>3.3.9</maven-core.version>


### PR DESCRIPTION
…dori.com/blog/cve-2021-44228/