### PR TITLE
PEG-2095: Upgrade jackson to 2.15.0 to fix security vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Security
+- Upgrade jackson to version 2.15.0 to fix security vulnerabilities:
+  - **CVE-2022-42003** Detail: https://cwe.mitre.org/data/definitions/502.html
+  - **CVE-2025-52999** Detail: https://cwe.mitre.org/data/definitions/121.html
+  - **CVE-2022-42004** Detail: https://cwe.mitre.org/data/definitions/400.html
+  - **CCVE-2025-49128** Detail: https://cwe.mitre.org/data/definitions/209.html
 
 ## [17.104.0-M1] - 2025-07-18
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,7 @@
         <hamcrest.regex.version>1.0.1</hamcrest.regex.version>
         <hamcrest.version>2.2</hamcrest.version>
         <hibernate.version>5.4.24.Final</hibernate.version>
-        <jackson.version>2.12.7</jackson.version>
-        <jackson.databind.version>2.12.7.1</jackson.databind.version>
+        <jackson.version>2.15.0</jackson.version>
         <jakarta.xml.bind-api.version>2.3.2</jakarta.xml.bind-api.version>
         <java.8.matchers.version>1.1</java.8.matchers.version>
         <javapoet.version>1.6.1</javapoet.version>


### PR DESCRIPTION
Draft pull request to keep for reference:

Unfortunately upgrading the Jackson libraries we use conflicts with the version that wildfly 26 uses. We have 3 options.
- Don't upgrade and live with the security vulnerabilities
- Upgrade the Jackson modules in all our current wildfly deployments
- Upgrade Wildfly to a later version that uses a more secure version of Jackson