### PR TITLE
Fix jakarta.cdi-api artifact ID to jakarta.enterprise.cdi-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
             </dependency>
             <dependency>
                 <groupId>jakarta.enterprise</groupId>
-                <artifactId>jakarta.cdi-api</artifactId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
                 <version>${cdi.api.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Summary

The `21.0.0-M1` release contained a wrong artifact ID for the CDI 4.0 API:

- **Wrong:** `jakarta.enterprise:jakarta.cdi-api` — this artifact does not exist on Maven Central
- **Correct:** `jakarta.enterprise:jakarta.enterprise.cdi-api` — the actual CDI 4.0 API artifact

This caused `Could not find artifact jakarta.enterprise:jakarta.cdi-api:jar:4.0.1` failures on CI agents with a fresh Maven cache.