### PR TITLE
Java 25 / WildFly 40 spike: cp-maven-common-bom

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -31,7 +31,7 @@ resources:
 pool:
   name: 'MDV-ADO-AGENT-AKS-01'
   demands:
-    - identifier -equals centos8-j17-postgres
+    - identifier -equals ubuntu-j25-postgres
  
 variables:
   - name: sonarqubeProject

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-parent-pom</artifactId>
-        <version>21.0.0-SNAPSHOT</version>
+        <version>25.104.0-M1</version>
     </parent>
 
     <artifactId>maven-common-bom</artifactId>
-    <version>21.0.0-SNAPSHOT</version>
+    <version>25.104.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>Bill of materials defining standard versions for dependencies of the Microservices
         framework
@@ -29,18 +29,18 @@
         <cpp.repo.name>maven-common-bom</cpp.repo.name>
 
         <!-- Jakarta EE APIs -->
-        <cdi.api.version>4.0.1</cdi.api.version>
-        <jakarta.activation-api.version>2.1.2</jakarta.activation-api.version>
-        <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
+        <cdi.api.version>4.1.0</cdi.api.version>
+        <jakarta.activation-api.version>2.1.3</jakarta.activation-api.version>
+        <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
         <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
         <jakarta.jms-api.version>3.1.0</jakarta.jms-api.version>
         <jakarta.json-api.version>2.1.3</jakarta.json-api.version>
-        <jakarta.mail-api.version>2.1.2</jakarta.mail-api.version>
+        <jakarta.mail-api.version>2.1.3</jakarta.mail-api.version>
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
-        <jakarta.xml.bind-api.version>4.0.0</jakarta.xml.bind-api.version>
-        <jee.api.version>10.0.0</jee.api.version>
-        <persistence-api.version>3.1.0</persistence-api.version>
-        <servlet.api.version>6.0.0</servlet.api.version>
+        <jakarta.xml.bind-api.version>4.0.2</jakarta.xml.bind-api.version>
+        <jee.api.version>11.0.0</jee.api.version>
+        <persistence-api.version>3.2.0</persistence-api.version>
+        <servlet.api.version>6.1.0</servlet.api.version>
 
         <!-- Legacy javax APIs — only kept for libraries that cannot yet be migrated -->
         <javax.mail.version>1.5.0</javax.mail.version>
@@ -49,16 +49,16 @@
         <jboss-ejb3-ext-api.version>2.4.0.Final</jboss-ejb3-ext-api.version>
         <jboss-logging.version>3.6.3.Final</jboss-logging.version>
         <jboss-vfs.version>3.3.2.Final</jboss-vfs.version>
-        <wildfly.version>34.0.1.Final</wildfly.version>
+        <wildfly.version>40.0.0.Final</wildfly.version>
 
         <!-- RESTEasy -->
-        <resteasy-client.version>6.2.15.Final</resteasy-client.version>
-        <resteasy-jaxrs.version>3.15.3.Final</resteasy-jaxrs.version>
-        <resteasy-multipart-provider.version>6.2.15.Final</resteasy-multipart-provider.version>
-        <resteasy.version>6.2.15.Final</resteasy.version>
+        <resteasy-client.version>7.0.0.Final</resteasy-client.version>
+        <resteasy-jaxrs.version>4.7.9.Final</resteasy-jaxrs.version>
+        <resteasy-multipart-provider.version>7.0.0.Final</resteasy-multipart-provider.version>
+        <resteasy.version>7.0.0.Final</resteasy.version>
 
-        <!-- Apache ActiveMQ Artemis -->
-        <artemis.jms.version>2.40.0</artemis.jms.version>
+        <!-- Apache Artemis -->
+        <artemis.jms.version>2.53.0</artemis.jms.version>
         <geronimo-jms.version>1.0-alpha-2</geronimo-jms.version>
 
         <!-- Apache Commons -->
@@ -72,14 +72,14 @@
         <commons.logging.version>1.3.6</commons.logging.version>
         <commons.validator.version>1.10.1</commons.validator.version>
 
-        <!-- Jackson: aligned to WildFly 32's bundled version (2.15.4) -->
+        <!-- Jackson: aligned to WildFly 40's bundled version (2.21.1) -->
         <!-- jackson-dataformat-yaml is pinned at 2.14.3 (last version using snakeyaml 1.x)
              because 2.15+ requires snakeyaml 2.x which breaks the raml-parser Maven plugin -->
-        <jackson-datatype-jakarta-jsonp.version>2.15.4</jackson-datatype-jakarta-jsonp.version>
-        <jackson.databind.version>2.15.4</jackson.databind.version>
+        <jackson-datatype-jakarta-jsonp.version>2.21.4</jackson-datatype-jakarta-jsonp.version>
+        <jackson.databind.version>2.21.4</jackson.databind.version>
         <jackson.dataformat.yaml.version>2.14.3</jackson.dataformat.yaml.version>
-        <jackson.version>2.15.4</jackson.version>
-        <jackson.version.annotations>2.15.4</jackson.version.annotations>
+        <jackson.version>2.21.4</jackson.version>
+        <jackson.version.annotations>2.21</jackson.version.annotations>
 
         <!-- JSON -->
         <glassfish-javax-json.version>1.1.4</glassfish-javax-json.version>
@@ -97,8 +97,8 @@
         <hibernate.version>6.6.1.Final</hibernate.version>
 
         <!-- Weld -->
-        <weld-junit5.version>1.2.2.Final</weld-junit5.version>
-        <weld.version>5.1.2.Final</weld.version>
+        <weld-junit5.version>4.0.2.Final</weld-junit5.version>
+        <weld.version>6.0.0.Final</weld.version>
 
         <!-- Apache TomEE / OpenEJB -->
         <openejb.version>10.1.4</openejb.version>
@@ -192,6 +192,11 @@
             <dependency>
                 <groupId>jakarta.enterprise</groupId>
                 <artifactId>jakarta.cdi-api</artifactId>
+                <version>${cdi.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
                 <version>${cdi.api.version}</version>
             </dependency>
             <dependency>
@@ -309,15 +314,15 @@
                         <artifactId>jgroups</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>org.apache.activemq</groupId>
+                        <groupId>org.apache.artemis</groupId>
                         <artifactId>artemis-core-client</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>org.apache.activemq</groupId>
+                        <groupId>org.apache.artemis</groupId>
                         <artifactId>artemis-commons</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>org.apache.activemq</groupId>
+                        <groupId>org.apache.artemis</groupId>
                         <artifactId>artemis-hqclient-protocol</artifactId>
                     </exclusion>
                 </exclusions>
@@ -367,21 +372,6 @@
             </dependency>
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
-                <artifactId>resteasy-jaxrs</artifactId>
-                <version>${resteasy-jaxrs.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>jakarta.activation</groupId>
-                        <artifactId>jakarta.activation-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.sun.activation</groupId>
-                        <artifactId>jakarta.activation</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-multipart-provider</artifactId>
                 <version>${resteasy-multipart-provider.version}</version>
                 <exclusions>
@@ -421,17 +411,17 @@
 
             <!-- ===== Apache ActiveMQ Artemis ===== -->
             <dependency>
-                <groupId>org.apache.activemq</groupId>
+                <groupId>org.apache.artemis</groupId>
                 <artifactId>artemis-commons</artifactId>
                 <version>${artemis.jms.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.activemq</groupId>
+                <groupId>org.apache.artemis</groupId>
                 <artifactId>artemis-core-client</artifactId>
                 <version>${artemis.jms.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.activemq</groupId>
+                <groupId>org.apache.artemis</groupId>
                 <artifactId>artemis-jakarta-client</artifactId>
                 <version>${artemis.jms.version}</version>
                 <exclusions>
@@ -446,7 +436,7 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.apache.activemq</groupId>
+                <groupId>org.apache.artemis</groupId>
                 <artifactId>artemis-jms-client</artifactId>
                 <version>${artemis.jms.version}</version>
                 <exclusions>
@@ -461,32 +451,32 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.apache.activemq</groupId>
+                <groupId>org.apache.artemis</groupId>
                 <artifactId>artemis-jms-server</artifactId>
                 <version>${artemis.jms.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.activemq</groupId>
+                <groupId>org.apache.artemis</groupId>
                 <artifactId>artemis-journal</artifactId>
                 <version>${artemis.jms.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.activemq</groupId>
+                <groupId>org.apache.artemis</groupId>
                 <artifactId>artemis-ra</artifactId>
                 <version>${artemis.jms.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.activemq</groupId>
+                <groupId>org.apache.artemis</groupId>
                 <artifactId>artemis-selector</artifactId>
                 <version>${artemis.jms.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.activemq</groupId>
+                <groupId>org.apache.artemis</groupId>
                 <artifactId>artemis-server</artifactId>
                 <version>${artemis.jms.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.activemq</groupId>
+                <groupId>org.apache.artemis</groupId>
                 <artifactId>artemis-service-extensions</artifactId>
                 <version>${artemis.jms.version}</version>
             </dependency>
@@ -1074,12 +1064,6 @@
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path-assert</artifactId>
                 <version>${jsonpath.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.hamcrest</groupId>
-                        <artifactId>hamcrest</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.jayway.restassured</groupId>


### PR DESCRIPTION
## Java 25 / WildFly 40 spike — cp-maven-common-bom

Spike to prove viability of skipping Java 21 and going straight to **Java 25 / WildFly 40 / Jakarta EE 11**. This is the central dependency version catalogue for the framework.

**Spike gate: cp-cake-shop integration tests — 42/42 passing ✅**

Version series: `25.104.0-M1-SNAPSHOT` — the middle number preserves the framework-E lineage (104), 25 = Java version.

### Key dependency version changes

| Dependency | Previous | Java 25 spike |
|---|---|---|
| WildFly BOM | 34.0.1.Final | **40.0.0.Final** |
| Jakarta EE | 10 | **11** |
| RESTEasy | 6.2.15.Final | **7.0.0.Final** |
| Artemis | 2.40.0 (`org.apache.activemq`) | **2.53.0 (`org.apache.artemis`)** |
| Jackson | 2.17.x | **2.21.x** (annotations=2.21, rest=2.21.3) |
| Weld | 5.1.2.Final | **6.0.0.Final** |
| WildFly Maven plugin | 4.2.2.Final | **6.0.0.Final** |
| JaCoCo | 0.8.12 | **0.8.14** (required for Java 25 class file major version 69) |
| maven-plugin-plugin | 3.13.x | **3.15.2** (ASM 9.9 — required for Java 25 bytecode analysis) |

### ⚠️ CI
CIs will fail until Java 25 build pipelines are created. **Do not merge until CI is green.**

### Related PRs (full spike chain)
cp-maven-super-pom → cp-maven-parent-pom → cp-maven-common-bom → cp-maven-framework-parent-pom → cp-file-service → cp-wiremock-service → cp-framework-libraries → cp-microservice-framework → cp-event-store → cp-cake-shop