### PR TITLE
Bump reflections 0.9.10 → 0.10.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <mvel2.version>2.5.2.Final</mvel2.version>
         <org.owasp.encoder.version>1.4.0</org.owasp.encoder.version>
         <raml-parser.version>0.8.18</raml-parser.version>
-        <reflections.version>0.9.10</reflections.version>
+        <reflections.version>0.10.2</reflections.version>
         <xbean.version>4.30</xbean.version>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
## Summary
- Upgrade `reflections` from `0.9.10` to `0.10.2` as part of the Java 25 / M2 technical debt cleanup

## Deferred (require code changes, not just version bumps — separate assessment needed)
- `disruptor` 3.4.4 → 4.x — package API changes
- `metrics` 3.2.3 → 4.x — package renamed
- `diff.utils` 1.3.0 → 4.x — package renamed (`difflib` → `com.github.difflib`)
- `findbugs` 3.0.1 → SpotBugs — groupId change + `@SuppressFBWarnings` migration across contexts

## Test plan
- [ ] Downstream builds compile and pass tests with updated reflections version