### PR TITLE
Bump parent maven-parent-pom to 25.104.0-M2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-parent-pom</artifactId>
-        <version>25.104.0-M1</version>
+        <version>25.104.0-M2</version>
     </parent>
 
     <artifactId>maven-common-bom</artifactId>


### PR DESCRIPTION
## Summary

- Bumps parent `maven-parent-pom` from `25.104.0-M1` to `25.104.0-M2`

Required before releasing `cp-maven-common-bom` as M2 — all projects in the 25.104.x chain must reference consistent milestone versions of shared dependencies.

The substantive changes (jakarta.el-api convergence pin + reflections bump) were already merged via #181.