### PR TITLE
Bump parent maven-parent-pom to 25.104.0-M3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-parent-pom</artifactId>
-        <version>25.104.0-M2</version>
+        <version>25.104.0-M3</version>
     </parent>
 
     <artifactId>maven-common-bom</artifactId>


### PR DESCRIPTION
Bumps parent maven-parent-pom from 25.104.0-M2 to 25.104.0-M3 for M3 release consistency.