### PR TITLE
Bump Artemis libs 2.53.0 -> 2.54.0 (release M7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ## [Unreleased]
 
+## [25.104.0-M7] - 2026-08-04
+### Changed
+- Bumped `artemis.jms.version` `2.53.0` → `2.54.0` — aligns the managed Apache Artemis client/server artifacts (`artemis-jakarta-client`, `artemis-jms-client`, `artemis-core-client`, `artemis-commons`, `artemis-server`, etc.) with the Java-17/production Artemis 2.54 upgrade and the 2.54.0 local broker in `cpp-developers-docker`. Verified with users-groups full ITs (96/0/0) against a 2.54 broker.
+
 ## [25.104.0-M6] - 2026-07-27
 ### Changed
 - Import the `org.junit:junit-bom` instead of pinning individual `junit-jupiter` / `junit-vintage` versions, so `junit-platform-launcher` stays aligned with `junit-platform-engine` (a drifting launcher version breaks Surefire/Failsafe test discovery — "OutputDirectoryCreator not available").

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <resteasy.version>7.0.0.Final</resteasy.version>
 
         <!-- Apache Artemis -->
-        <artemis.jms.version>2.53.0</artemis.jms.version>
+        <artemis.jms.version>2.54.0</artemis.jms.version>
         <geronimo-jms.version>1.0-alpha-2</geronimo-jms.version>
 
         <!-- Apache Commons -->


### PR DESCRIPTION
## What
Bump `artemis.jms.version` `2.53.0` → `2.54.0` in `cp-maven-common-bom`, upgrading all the managed Apache Artemis client/server artifacts.

## Why
Mirror the Java-17 / production Artemis upgrade to 2.54, and keep the platform's managed Artemis client aligned with the 2.54.0 local broker (`cpp-developers-docker` [#227](https://github.com/hmcts/cpp-developers-docker/pull/227)).

## Testing
- `org.apache.artemis:artemis-*:2.54.0` resolve from Artifactory.
- **users-groups full ITs green (96/0/0)** with the whole Artemis client set forced to 2.54, running against a 2.54.0 broker.

## Note
This cascades: once released (M7), the framework → platform → context chain should pick up the 2.54 client on their next milestone bumps.